### PR TITLE
Make dub package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/dmpp
+dmpp.so
+dmpp.dylib
+dmpp.dll
+dmpp.a
+dmpp.lib
+dmpp-test-*
+*.exe
+*.o
+*.obj
+*.lst

--- a/dub.json
+++ b/dub.json
@@ -1,0 +1,15 @@
+{
+	"authors": [
+		"Walter Bright"
+	],
+	"copyright": "Copyright © 2021, Walter Bright",
+	"description": "A C/C++ preprocessor written in DLang",
+	"license": "Boost 1.0",
+	"name": "dmpp",
+	"mainSourceFile": "src/dmd/main.d",
+	"importPaths": [
+		"src/dmd"
+	],
+	"buildRequirements": [ "allowWarnings" ],
+	"targetType": "executable"
+}

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,0 +1,5 @@
+{
+	"fileVersion": 1,
+	"versions": {
+	}
+}

--- a/src/dmd/charclass.d
+++ b/src/dmd/charclass.d
@@ -25,7 +25,7 @@ enum CClass
     multiTok        = 8,
 }
 
-immutable ubyte[256] cclassTable;
+const ubyte[256] cclassTable;
 
 /******************************************
  * Characters that make up the start of an identifier.

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -806,7 +806,7 @@ struct Lexer(R) if (isInputRange!R)
                      // \u or \U could be start of identifier
                     src.popFront();
                     err_fatal("unrecognized preprocessor token x%02x", c);
-                    assert(0);   // not handled yet
+                    //assert(0);   // not handled yet
                     break;
 
                 case ESC.expand:

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -451,8 +451,8 @@ struct Lexer(R) if (isInputRange!R)
                                 {
                                     src.popFront();
                                     src = src.skipCppComment();
+                                    continue;
                                 }
-                                continue;
 
                             case '*':
                                 static if (isContext)
@@ -819,7 +819,7 @@ struct Lexer(R) if (isInputRange!R)
                         noExpand = false;
                         return;
                     }
-                    goto default;
+                    else goto default;
 
                 default:
                     err_fatal("unrecognized preprocessor token x%02x", c);

--- a/src/dmd/lexer.d
+++ b/src/dmd/lexer.d
@@ -806,8 +806,7 @@ struct Lexer(R) if (isInputRange!R)
                      // \u or \U could be start of identifier
                     src.popFront();
                     err_fatal("unrecognized preprocessor token x%02x", c);
-                    //assert(0);   // not handled yet
-                    break;
+                    assert(0);
 
                 case ESC.expand:
                     static if (isContext)


### PR DESCRIPTION
Add some initial dub.json file to build dmpp as a dub executable page.

dmpp might be useful as part of a future 'dub' or 'dmd-tools' package version to support ImportC in a more general way and
without an dependancy on gcc or clang.

Also fixed some obvious warnings from compilers (dmd 2.098.0 and ldc 1.28.0)
